### PR TITLE
Support leading zeroes

### DIFF
--- a/CacheJSON.cls
+++ b/CacheJSON.cls
@@ -242,6 +242,12 @@ ClassMethod Encode(data As %DataType) As %String
     q """"_..Escape(data)_""""
   }
   elseif $ISVALIDNUM(data) {
+  
+    ;; If this number begins with a leading 0, and is followed by another digit, then it should be quoted.
+    if ($MATCH(data, "^0[0-9].*")=1) {
+ 	Q """"_data_""""
+    }
+  
     // type number
     q data
     

--- a/TestJSON.cls
+++ b/TestJSON.cls
@@ -78,4 +78,35 @@ Method TestJSON()
     Do $$$AssertEquals(1,0,"Exception thrown - " _ tException.Code_ ": " _ tException.Name _ " " _ tException.Data _ " " _ tException.Location)
   }
 }
+Method TestLeadingZerosValuesAreEscaped()
+{
+	Set input = "000123"
+	set output = ##class(App.API.Helper.CacheJSON).Encode(input)
+	set expected = """"_input_""""
+	Do $$$AssertEquals(output, expected, "Checking that a number with leading zeros is escaped")
+}
+
+Method TestZeroValueIsNotEscaped()
+{
+	Set input = "0"
+	set output = ##class(App.API.Helper.CacheJSON).Encode(input)
+	set expected = input
+	Do $$$AssertEquals(output, expected, "Checking that a zero value is not escaped")
+}
+
+Method TestZeroFollowedByDecimalIsNotQuoted()
+{
+	Set input = "0.1"
+	set output = ##class(App.API.Helper.CacheJSON).Encode(input)
+	set expected = """"_input_""""
+	Do $$$AssertEquals(output, expected, "Checking that a zero value followed by a decimal is not escaped")
+}
+
+Method TestMultipleZerosFollowedByDecimalIsQuoted()
+{
+	Set input = "00.1"
+	set output = ##class(App.API.Helper.CacheJSON).Encode(input)
+	set expected = """"_input_""""
+	Do $$$AssertEquals(output, expected, "Checking that a zero value followed by a decimal is not escaped")
+}
 }


### PR DESCRIPTION
The JSON specification states that numbers should not be prefixed with a 0 unless it is immediately followed by a period.  Currently the JSON encoder does not follow this requirement.  This pull requests adds a little logic to check for numbers beginning with zero, and then quotes those numbers, treating the value as a string.