### PR TITLE
Bug fix

### DIFF
--- a/CacheJSON.cls
+++ b/CacheJSON.cls
@@ -17,7 +17,14 @@ Class CacheJSON Extends %String
 					 	Strings containing a period character need to be escaped with quotes.
 					 Added classmethod to return an object loaded with the properties from an encoded JSON string.
 			
+		Modified by: Yuval Golan
+		Date: 12/17/2014
+		Version 1.2
+		Description: Fixed a bug that allowed %String property types to be unescaped when they qualified for $ISVALIDNUM()
+		                Strings containing only numeric characters that start with zero (i.e. "0123")
+		             Fixed a bug that returned inner objects as %ArrayOfDataTypes instead of there class type.
 	*/
+
 Parameter EscapeChar As COSEXPRESSION = "$LB($LB(""\"",""\\""),$LB($C(13),""\n""),$LB($C(10),""\r""),$LB($C(9),""\t""),$LB("""""""",""\""""""),$LB($C(8),""\b""),$LB($C(12),""\f""))";
 
 Parameter UnEscapeChar As COSEXPRESSION = "$LB(""\\"",""\n"",""\r"",""\t"",""\"""""",""\b"",""\f"")";
@@ -241,7 +248,8 @@ ClassMethod Encode(data As %DataType) As %String
     q:data="" "null"
     q """"_..Escape(data)_""""
   }
-  elseif $ISVALIDNUM(data) {
+  elseif $ISVALIDNUM(data)&&((data=0)||($e(data)'=0)) {
+	  ;; If it's a numeric string that start with zero (ie. 0123) then it's not a number, but still $ISVALIDNUM will return true.
     // type number
     q data
     
@@ -329,11 +337,24 @@ ClassMethod GetObjectFromJSON(JSON As %String) As %RegisteredObject [ CodeMode =
 		
 		// Rip through each property of the class.. that does not start with a %
 		// Insert each property into the object to return
+		#dim prop As %Dictionary.CompiledProperty
 		For i = 1:1:%compiledclass.Properties.Count() {
-	        Set prop = %compiledclass.Properties.GetAt(i).Name
-	        IF ($EXTRACT(prop) '= "%") {
+	        Set prop = %compiledclass.Properties.GetAt(i)
+	        set propName=prop.Name
+	        IF ($EXTRACT(propName) '= "%") {
+		        set propType=prop.Type
+		        set propTypeClass="" if propType'="" set propTypeClass=##class(%Dictionary.CompiledClass).%OpenId(propType)
+		        set isOBJ=0 if $isobject(propTypeClass),propTypeClass.ClassType'="datatype" set isOBJ=1
 		        //Do %code.WriteLine(" Do array.SetAt(.."_prop_","""_prop_""")")
-		        Do %code.WriteLine(" Set return."_prop_" = myDecodedArray.GetAt("""_prop_""")")
+		        if (isOBJ) {
+			        Do %code.Write(" set strJSON = ..Encode(myDecodedArray.GetAt("""_propName_"""))")
+			        Do %code.WriteLine(" // As "_propType_" (class)")
+			        Do %code.WriteLine(" Set return."_propName_" = ##class("_propType_").GetObjectFromJSON(strJSON)")
+		        }
+		        else {
+			        Do %code.Write(" Set return."_propName_" = myDecodedArray.GetAt("""_propName_""")")
+			        Do %code.WriteLine(" // As "_propType_" (datatype)")
+		        }
 	        }
 	    }
 	    

--- a/CacheJSON.cls
+++ b/CacheJSON.cls
@@ -17,7 +17,15 @@ Class CacheJSON Extends %String
 					 	Strings containing a period character need to be escaped with quotes.
 					 Added classmethod to return an object loaded with the properties from an encoded JSON string.
 			
+		Modified by: Yuval Golan
+		Date: 12/17/2014
+		Version 1.2
+		Description: Fixed a bug that allowed %String property types to be unescaped when they qualified for $ISVALIDNUM()
+		                For example strings containing only numeric characters that start with zero (i.e. "0123") and strings
+                                that start with a plus sign and then numeric characters (i.e. "+123").
+		             Fixed a bug that returned inner objects as %ArrayOfDataTypes instead of there class type.
 	*/
+
 Parameter EscapeChar As COSEXPRESSION = "$LB($LB(""\"",""\\""),$LB($C(13),""\n""),$LB($C(10),""\r""),$LB($C(9),""\t""),$LB("""""""",""\""""""),$LB($C(8),""\b""),$LB($C(12),""\f""))";
 
 Parameter UnEscapeChar As COSEXPRESSION = "$LB(""\\"",""\n"",""\r"",""\t"",""\"""""",""\b"",""\f"")";
@@ -234,15 +242,14 @@ ClassMethod Encode(data As %DataType) As %String
     }
   }
   elseif ($FIND(data,".")) {
-	;; This $ISVALIDNUM below is causing some %String property types that are valid numbers (ie. .1293394) to be unescaped
-  	;; $ISVALIDNUM allows for periods. Need to check for a . in another elseif and escape it like a string "".
+	;; Valid numbers that start with period (ie. .1293394) should be escaped like a string.
 
-	//type string
-    q:data="" "null"
+    //type string
     q """"_..Escape(data)_""""
   }
-  elseif $ISVALIDNUM(data) {
-    // type number
+  elseif (+data=data) {
+  	;; If it's a numeric value then return the value as is.
+    //type number
     q data
     
   }
@@ -329,11 +336,24 @@ ClassMethod GetObjectFromJSON(JSON As %String) As %RegisteredObject [ CodeMode =
 		
 		// Rip through each property of the class.. that does not start with a %
 		// Insert each property into the object to return
+		#dim prop As %Dictionary.CompiledProperty
 		For i = 1:1:%compiledclass.Properties.Count() {
-	        Set prop = %compiledclass.Properties.GetAt(i).Name
-	        IF ($EXTRACT(prop) '= "%") {
+	        Set prop = %compiledclass.Properties.GetAt(i)
+	        set propName=prop.Name
+	        IF ($EXTRACT(propName) '= "%") {
+		        set propType=prop.Type
+		        set propTypeClass="" if propType'="" set propTypeClass=##class(%Dictionary.CompiledClass).%OpenId(propType)
+		        set isOBJ=0 if $isobject(propTypeClass),propTypeClass.ClassType'="datatype" set isOBJ=1
 		        //Do %code.WriteLine(" Do array.SetAt(.."_prop_","""_prop_""")")
-		        Do %code.WriteLine(" Set return."_prop_" = myDecodedArray.GetAt("""_prop_""")")
+		        if (isOBJ) {
+			        Do %code.Write(" set strJSON = ..Encode(myDecodedArray.GetAt("""_propName_"""))")
+			        Do %code.WriteLine(" // As "_propType_" (class)")
+			        Do %code.WriteLine(" Set return."_propName_" = ##class("_propType_").GetObjectFromJSON(strJSON)")
+		        }
+		        else {
+			        Do %code.Write(" Set return."_propName_" = myDecodedArray.GetAt("""_propName_""")")
+			        Do %code.WriteLine(" // As "_propType_" (datatype)")
+		        }
 	        }
 	    }
 	    

--- a/CacheJSON.cls
+++ b/CacheJSON.cls
@@ -21,8 +21,7 @@ Class CacheJSON Extends %String
 		Date: 12/17/2014
 		Version 1.2
 		Description: Fixed a bug that allowed %String property types to be unescaped when they qualified for $ISVALIDNUM()
-		                For example strings containing only numeric characters that start with zero (i.e. "0123") and strings
-                                that start with a plus sign and then numeric characters (i.e. "+123").
+		                Strings containing only numeric characters that start with zero (i.e. "0123")
 		             Fixed a bug that returned inner objects as %ArrayOfDataTypes instead of there class type.
 	*/
 
@@ -242,14 +241,16 @@ ClassMethod Encode(data As %DataType) As %String
     }
   }
   elseif ($FIND(data,".")) {
-	;; Valid numbers that start with period (ie. .1293394) should be escaped like a string.
+	;; This $ISVALIDNUM below is causing some %String property types that are valid numbers (ie. .1293394) to be unescaped
+  	;; $ISVALIDNUM allows for periods. Need to check for a . in another elseif and escape it like a string "".
 
-    //type string
+	//type string
+    q:data="" "null"
     q """"_..Escape(data)_""""
   }
-  elseif (+data=data) {
-  	;; If it's a numeric value then return the value as is.
-    //type number
+  elseif $ISVALIDNUM(data)&&((data=0)||($e(data)'=0)) {
+	  ;; If it's a numeric string that start with zero (ie. 0123) then it's not a number, but still $ISVALIDNUM will return true.
+    // type number
     q data
     
   }

--- a/CacheJSON.cls
+++ b/CacheJSON.cls
@@ -21,7 +21,8 @@ Class CacheJSON Extends %String
 		Date: 12/17/2014
 		Version 1.2
 		Description: Fixed a bug that allowed %String property types to be unescaped when they qualified for $ISVALIDNUM()
-		                Strings containing only numeric characters that start with zero (i.e. "0123")
+		                For example strings containing only numeric characters that start with zero (i.e. "0123") and strings
+                                that start with a plus sign and then numeric characters (i.e. "+123").
 		             Fixed a bug that returned inner objects as %ArrayOfDataTypes instead of there class type.
 	*/
 
@@ -241,16 +242,14 @@ ClassMethod Encode(data As %DataType) As %String
     }
   }
   elseif ($FIND(data,".")) {
-	;; This $ISVALIDNUM below is causing some %String property types that are valid numbers (ie. .1293394) to be unescaped
-  	;; $ISVALIDNUM allows for periods. Need to check for a . in another elseif and escape it like a string "".
+	;; Valid numbers that start with period (ie. .1293394) should be escaped like a string.
 
-	//type string
-    q:data="" "null"
+    //type string
     q """"_..Escape(data)_""""
   }
-  elseif $ISVALIDNUM(data)&&((data=0)||($e(data)'=0)) {
-	  ;; If it's a numeric string that start with zero (ie. 0123) then it's not a number, but still $ISVALIDNUM will return true.
-    // type number
+  elseif (+data=data) {
+  	;; If it's a numeric value then return the value as is.
+    //type number
     q data
     
   }

--- a/CacheJSON.cls
+++ b/CacheJSON.cls
@@ -17,14 +17,7 @@ Class CacheJSON Extends %String
 					 	Strings containing a period character need to be escaped with quotes.
 					 Added classmethod to return an object loaded with the properties from an encoded JSON string.
 			
-		Modified by: Yuval Golan
-		Date: 12/17/2014
-		Version 1.2
-		Description: Fixed a bug that allowed %String property types to be unescaped when they qualified for $ISVALIDNUM()
-		                Strings containing only numeric characters that start with zero (i.e. "0123")
-		             Fixed a bug that returned inner objects as %ArrayOfDataTypes instead of there class type.
 	*/
-
 Parameter EscapeChar As COSEXPRESSION = "$LB($LB(""\"",""\\""),$LB($C(13),""\n""),$LB($C(10),""\r""),$LB($C(9),""\t""),$LB("""""""",""\""""""),$LB($C(8),""\b""),$LB($C(12),""\f""))";
 
 Parameter UnEscapeChar As COSEXPRESSION = "$LB(""\\"",""\n"",""\r"",""\t"",""\"""""",""\b"",""\f"")";
@@ -248,8 +241,7 @@ ClassMethod Encode(data As %DataType) As %String
     q:data="" "null"
     q """"_..Escape(data)_""""
   }
-  elseif $ISVALIDNUM(data)&&((data=0)||($e(data)'=0)) {
-	  ;; If it's a numeric string that start with zero (ie. 0123) then it's not a number, but still $ISVALIDNUM will return true.
+  elseif $ISVALIDNUM(data) {
     // type number
     q data
     
@@ -337,24 +329,11 @@ ClassMethod GetObjectFromJSON(JSON As %String) As %RegisteredObject [ CodeMode =
 		
 		// Rip through each property of the class.. that does not start with a %
 		// Insert each property into the object to return
-		#dim prop As %Dictionary.CompiledProperty
 		For i = 1:1:%compiledclass.Properties.Count() {
-	        Set prop = %compiledclass.Properties.GetAt(i)
-	        set propName=prop.Name
-	        IF ($EXTRACT(propName) '= "%") {
-		        set propType=prop.Type
-		        set propTypeClass="" if propType'="" set propTypeClass=##class(%Dictionary.CompiledClass).%OpenId(propType)
-		        set isOBJ=0 if $isobject(propTypeClass),propTypeClass.ClassType'="datatype" set isOBJ=1
+	        Set prop = %compiledclass.Properties.GetAt(i).Name
+	        IF ($EXTRACT(prop) '= "%") {
 		        //Do %code.WriteLine(" Do array.SetAt(.."_prop_","""_prop_""")")
-		        if (isOBJ) {
-			        Do %code.Write(" set strJSON = ..Encode(myDecodedArray.GetAt("""_propName_"""))")
-			        Do %code.WriteLine(" // As "_propType_" (class)")
-			        Do %code.WriteLine(" Set return."_propName_" = ##class("_propType_").GetObjectFromJSON(strJSON)")
-		        }
-		        else {
-			        Do %code.Write(" Set return."_propName_" = myDecodedArray.GetAt("""_propName_""")")
-			        Do %code.WriteLine(" // As "_propType_" (datatype)")
-		        }
+		        Do %code.WriteLine(" Set return."_prop_" = myDecodedArray.GetAt("""_prop_""")")
 	        }
 	    }
 	    

--- a/TestJSON.cls
+++ b/TestJSON.cls
@@ -78,4 +78,35 @@ Method TestJSON()
     Do $$$AssertEquals(1,0,"Exception thrown - " _ tException.Code_ ": " _ tException.Name _ " " _ tException.Data _ " " _ tException.Location)
   }
 }
+Method TestLeadingZerosValuesAreEscaped()
+{
+	Set input = "000123"
+	set output = ##class(App.API.Helper.CacheJSON).Encode(input)
+	set expected = """"_input_""""
+	Do $$$AssertEquals(output, expected, "Checking that a number with leading zeros is escaped")
+}
+
+Method TestZeroValueIsNotEscaped()
+{
+	Set input = "0"
+	set output = ##class(App.API.Helper.CacheJSON).Encode(input)
+	set expected = input
+	Do $$$AssertEquals(output, expected, "Checking that a zero value is not escaped")
+}
+
+Method TestZeroFollowedByDecimalIsNotQuoted()
+{
+	Set input = "0.1"
+	set output = ##class(App.API.Helper.CacheJSON).Encode(input)
+	set expected = """"_input_""""
+	Do $$$AssertEquals(output, expected, "Checking that a zero value followed by a decimal is not escaped")
+}
+
+Method TestMultipleZerosFollowedByDecimalIsQuoted()
+{
+	Set input = "00.1"
+	set output = ##class(App.API.Helper.CacheJSON).Encode(input)
+	set expected = """"_input_""""
+	Do $$$AssertEquals(output, expected, "Checking that a zero value followed by a decimal is not escaped")
+}
 }


### PR DESCRIPTION
1. Fixed a bug that allowed %String property types to be unescaped when
they qualified for $ISVALIDNUM(). Strings containing only numeric
characters that start with zero (i.e. "0123")
2. Fixed a bug that returned inner objects as %ArrayOfDataTypes instead
of there class type.