### PR TITLE
fix leading zeroes json bug

### DIFF
--- a/CacheJSON.cls
+++ b/CacheJSON.cls
@@ -241,7 +241,7 @@ ClassMethod Encode(data As %DataType) As %String
     q:data="" "null"
     q """"_..Escape(data)_""""
   }
-  elseif $ISVALIDNUM(data) {
+  elseif $ISVALIDNUM(data) && ($l(data) = $l($number(data))) {
     // type number
     q data
     


### PR DESCRIPTION
On some browser number with leading zeroes are considered strings. When
receiving json number values with leading zeroes, instead of a string,
an error occurs.

This change checks that the number does not contain leading zeroes.
